### PR TITLE
Add `mapping_id` to JSON response

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -1,0 +1,1 @@
+SSSOM_API_MAPPING_ID = "sssom_api:mapping_id"

--- a/src/database/sparql_implementation.py
+++ b/src/database/sparql_implementation.py
@@ -107,7 +107,6 @@ class SparqlImpl(SparqlImplementation):
     return out
 
   def add_id(self, row):
-    print(row['_x'])
     if row.get('other'):
       other = json.loads(row["other"])
       other["mapping_id"] = row["_x"]

--- a/src/database/sparql_implementation.py
+++ b/src/database/sparql_implementation.py
@@ -106,13 +106,13 @@ class SparqlImpl(SparqlImplementation):
         out.append(v["value"])
     return out
 
-  def add_id(self, row):
+  def add_id(self, row, name_id):
     if row.get('other'):
       other = json.loads(row["other"])
       other["mapping_id"] = row["_x"]
       row["other"] = json.dumps(other)
     else:
-      row["other"] = json.dumps({"mapping_id": row["_x"]})
+      row["other"] = json.dumps({f"{name_id}": row["_x"]})
     row.pop("_x")
   
     return row
@@ -121,7 +121,7 @@ class SparqlImpl(SparqlImplementation):
     default_query = self.default_query(type=Mapping.class_class_uri, slots=self.schema_view.mapping_slots.copy(), field=field, value=value)
     bindings = self._query(default_query)
     for row in bindings:
-      r = self.add_id(self.transform_result(row))
+      r = self.add_id(self.transform_result(row), "sssomapi_mapping_id")
       r[f"{field}"] = value
       m = create_sssom_mapping(**r)
       if m is not None:
@@ -140,7 +140,7 @@ class SparqlImpl(SparqlImplementation):
     default_query = self.add_filters(self.default_query(Mapping.class_class_uri, self.schema_view.mapping_slots.copy()), filter)
     bindings = self._query(default_query)
     for row in bindings:
-      r = self.add_id(self.transform_result(row))
+      r = self.add_id(self.transform_result(row), "sssomapi_mapping_id")
       m = create_sssom_mapping(**r)
       if m is not None:
         yield m
@@ -174,7 +174,7 @@ class SparqlImpl(SparqlImplementation):
     default_query = self.default_query(Mapping.class_class_uri, slots=self.schema_view.mapping_slots.copy()+["mapping_set"], field="mapping_set", value=f'{SSSOM}{id}', inverse=True)
     bindings = self._query(default_query)
     for row in bindings:
-      r = self.add_id(self.transform_result(row))
+      r = self.add_id(self.transform_result(row), "sssomapi_mapping_id")
       m = create_sssom_mapping(**r)
       if m is not None:
         yield m

--- a/src/database/sparql_implementation.py
+++ b/src/database/sparql_implementation.py
@@ -140,7 +140,7 @@ class SparqlImpl(SparqlImplementation):
     default_query = self.add_filters(self.default_query(Mapping.class_class_uri, self.schema_view.mapping_slots.copy()), filter)
     bindings = self._query(default_query)
     for row in bindings:
-      r = self.add_id(self.transform_result(row), "sssomapi_mapping_id")
+      r = self.add_id(self.transform_result(row), "sssom_api:mapping_id")
       m = create_sssom_mapping(**r)
       if m is not None:
         yield m
@@ -174,7 +174,7 @@ class SparqlImpl(SparqlImplementation):
     default_query = self.default_query(Mapping.class_class_uri, slots=self.schema_view.mapping_slots.copy()+["mapping_set"], field="mapping_set", value=f'{SSSOM}{id}', inverse=True)
     bindings = self._query(default_query)
     for row in bindings:
-      r = self.add_id(self.transform_result(row), "sssomapi_mapping_id")
+      r = self.add_id(self.transform_result(row), "sssom_api:mapping_id")
       m = create_sssom_mapping(**r)
       if m is not None:
         yield m

--- a/src/database/sparql_implementation.py
+++ b/src/database/sparql_implementation.py
@@ -18,6 +18,7 @@ from sssom_schema import SSSOM
 
 from ..models import Mapping, MappingSet
 from ..utils import parse_fields_type
+from ..constants import SSSOM_API_MAPPING_ID
 
 import json
 
@@ -121,7 +122,7 @@ class SparqlImpl(SparqlImplementation):
     default_query = self.default_query(type=Mapping.class_class_uri, slots=self.schema_view.mapping_slots.copy(), field=field, value=value)
     bindings = self._query(default_query)
     for row in bindings:
-      r = self.add_id(self.transform_result(row), "sssomapi_mapping_id")
+      r = self.add_id(self.transform_result(row), SSSOM_API_MAPPING_ID)
       r[f"{field}"] = value
       m = create_sssom_mapping(**r)
       if m is not None:
@@ -140,7 +141,7 @@ class SparqlImpl(SparqlImplementation):
     default_query = self.add_filters(self.default_query(Mapping.class_class_uri, self.schema_view.mapping_slots.copy()), filter)
     bindings = self._query(default_query)
     for row in bindings:
-      r = self.add_id(self.transform_result(row), "sssom_api:mapping_id")
+      r = self.add_id(self.transform_result(row), SSSOM_API_MAPPING_ID)
       m = create_sssom_mapping(**r)
       if m is not None:
         yield m
@@ -174,7 +175,7 @@ class SparqlImpl(SparqlImplementation):
     default_query = self.default_query(Mapping.class_class_uri, slots=self.schema_view.mapping_slots.copy()+["mapping_set"], field="mapping_set", value=f'{SSSOM}{id}', inverse=True)
     bindings = self._query(default_query)
     for row in bindings:
-      r = self.add_id(self.transform_result(row), "sssom_api:mapping_id")
+      r = self.add_id(self.transform_result(row), SSSOM_API_MAPPING_ID)
       m = create_sssom_mapping(**r)
       if m is not None:
         yield m


### PR DESCRIPTION
Fixes #34 

All endpoints returning `Mapping` included the `mapping_id` in the `other` attribute.