### PR TITLE
Add facets to each page

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ sssom
 oaklib==v0.1.71
 pydantic[dotenv]
 curies
+toolz

--- a/src/models.py
+++ b/src/models.py
@@ -27,7 +27,7 @@ class PaginationInfo(BaseModel):
 
 class FacetInfo(BaseModel):
   mapping_justification: dict
-  predicate: dict
+  predicate_id: dict
 
 
 class Page(GenericModel, Generic[T]):

--- a/src/models.py
+++ b/src/models.py
@@ -7,11 +7,6 @@ from pydantic.generics import GenericModel
 from sssom_schema import Mapping, MappingSet, MappingRegistry, MappingSetReference
 
 T = TypeVar("T")
-# class ResponseMapping(BaseModel):
-#   subject_id: Mapping.subject_id
-#   predicate_id: Mapping.predicate_id
-#   object_id: Mapping.object_id
-#   mapping_justification: Mapping.mapping_justification
 
 class PaginationParams(BaseModel):
   request: Request
@@ -30,9 +25,15 @@ class PaginationInfo(BaseModel):
   total_pages: int
 
 
+class FacetInfo(BaseModel):
+  mapping_justification: dict
+  predicate: dict
+
+
 class Page(GenericModel, Generic[T]):
   data: List[T]
   pagination: PaginationInfo
+  facets: FacetInfo
 
 
 class SearchEntity(BaseModel):

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,9 +1,9 @@
 
 from typing import Iterable, TypeVar, Union, List
 import itertools
-import functools
 import math
-from collections import Counter
+from toolz.recipes import countby
+from toolz.itertoolz import count
 
 from fastapi import Request
 
@@ -26,7 +26,7 @@ def paginate(iterable: Iterable[T], page: int, limit: int, request: Request) -> 
     next_page = None
     data = []
     iter_data, iter_total, iter_facets = itertools.tee(iterable, 3)
-    total_items = functools.reduce(lambda prev, curr: prev + 1, iter_total, 0)
+    total_items = count(iter_total)
     total_pages = math.ceil(total_items / limit)
     for idx, item in enumerate(iter_data):
         if idx == start - 1:
@@ -52,8 +52,8 @@ def _create_facets(data: Iterable[T]) -> FacetInfo:
     iter_mj, iter_pred = itertools.tee(data)
     
     return FacetInfo(
-        mapping_justification=dict(Counter(list(map(lambda d: d["mapping_justification"], iter_mj)))),
-        predicate=dict(Counter(list(map(lambda d: d["predicate_id"], iter_pred)))),
+        mapping_justification=countby(lambda d: d["mapping_justification"], iter_mj),
+        predicate_id=countby(lambda d: d["predicate_id"], iter_pred),
     )
 
 def parser_filter(datamodel: T, filter: Union[List[str], None] = None) -> Union[List[dict], None]:


### PR DESCRIPTION
Related to #51

At the moment it's returning `mapping_justification` and `predicate_id` that are part of the mapping model.

The `mapping_set_title` is part of the mapping set and need extra work to get them.

Facets object shows the list of values for each facet and the total number in total items:

```json
"facets": {
    "mapping_justification": {
      "https://w3id.org/semapv/LexicalMatching": 185,
      "https://w3id.org/semapv/LogicalReasoning": 115,
      "https://w3id.org/semapv/ManualMappingCuration": 1092,
      "https://w3id.org/semapv/UnspecifiedMatching": 6740
    },
    "predicate": {
      "http://www.w3.org/2004/02/skos/core#closeMatch": 347,
      "http://www.w3.org/2004/02/skos/core#exactMatch": 665,
      "http://www.w3.org/2004/02/skos/core#narrowMatch": 155,
      "http://www.w3.org/2002/07/owl#equivalentClass": 6740,
      "http://www.w3.org/2004/02/skos/core#relatedMatch": 105,
      "http://www.w3.org/2004/02/skos/core#broadMatch": 120
    }
  }
```
 