### PR TITLE
Update RDF4J setup

### DIFF
--- a/rdf4j_sssom.txt
+++ b/rdf4j_sssom.txt
@@ -1,12 +1,11 @@
 show repositories
 drop sssom.
 yes
-create memory.
+create native.
 sssom
 SSSOM triplestore
 10000
-true
-0
+spoc,posc
 org.eclipse.rdf4j.query.algebra.evaluation.impl.StrictEvaluationStrategyFactory
 show repositories
 open sssom.


### PR DESCRIPTION
Related to #76

Instead of creating a memory based RDF repository, it's better to create a native repository that uses on-disk data structure.

The native repository is the recommended solution for datasets with up to 100 milion triples. ([docs](https://rdf4j.org/documentation/programming/repository/#native-rdf-repository))