### PR TITLE
Send predicate_id as curie in the facets object

### DIFF
--- a/src/database/sparql_implementation.py
+++ b/src/database/sparql_implementation.py
@@ -21,7 +21,7 @@ class SparqlImpl(SparqlImplementation):
         if value.startswith("http"):
             return f"<{value}>"
         elif ":" in value:
-            return self.curie_to_sparql(value)
+            return f"<{expand_uri(value)}>"
         else:
             return f'"{value}"'
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -59,7 +59,7 @@ def _create_facets(data: Iterable[object]) -> FacetInfo:
     list_iter_conf = list(iter_conf)
     return FacetInfo(
         mapping_justification=countby(lambda d: d["mapping_justification"], iter_mj),
-        predicate_id=countby(lambda d: d["predicate_id"], iter_pred),
+        predicate_id=countby(lambda d: compress_uri(d["predicate_id"]), iter_pred),
         confidence=ConfidenceInfo(
             min=min(
                 map(


### PR DESCRIPTION
Related to #51

It's also possible to search using predicate_id as curie in the `entities` endpoint. (Related to #52)